### PR TITLE
Updated Alpine version to 3.9

### DIFF
--- a/pdns/Dockerfile.alpine
+++ b/pdns/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 MAINTAINER "Peter Schiffer" <peter@rfv.sk>
 
 RUN apk add --no-cache \


### PR DESCRIPTION
Alpine has been updated to 3.9 and powerdns to 4.1.5. It should be possible to upgrade without problems.