### PR TITLE
adding option to skip db create

### DIFF
--- a/pdns/docker-entrypoint.sh
+++ b/pdns/docker-entrypoint.sh
@@ -29,7 +29,9 @@ until $MYSQL_COMMAND -e ';' ; do
     sleep 3
 done
 
-$MYSQL_COMMAND -e "CREATE DATABASE IF NOT EXISTS ${PDNS_gmysql_dbname}"
+if [ "${SKIP_DB_CREATE}" != 'true' ]; then
+    $MYSQL_COMMAND -e "CREATE DATABASE IF NOT EXISTS ${PDNS_gmysql_dbname}"
+fi
 
 MYSQL_CHECK_IF_HAS_TABLE="SELECT COUNT(DISTINCT table_name) FROM information_schema.columns WHERE table_schema = '${PDNS_gmysql_dbname}';"
 MYSQL_NUM_TABLE=$($MYSQL_COMMAND --batch --skip-column-names -e "$MYSQL_CHECK_IF_HAS_TABLE")

--- a/pdns/docker-entrypoint.sh
+++ b/pdns/docker-entrypoint.sh
@@ -29,7 +29,7 @@ until $MYSQL_COMMAND -e ';' ; do
     sleep 3
 done
 
-if [ "${SKIP_DB_CREATE}" != 'true' ]; then
+if [ "${SKIP_DB_CREATE:-false}" != 'true' ]; then
     $MYSQL_COMMAND -e "CREATE DATABASE IF NOT EXISTS ${PDNS_gmysql_dbname}"
 fi
 


### PR DESCRIPTION
This allows passing an env var to skip the DB create; required for databases with read-only permissions.

Let me know if there's anything you'd like me to modify with this change.