### PR TITLE
Fix typo in ipv6 network address compose file

### DIFF
--- a/docker-compose-mysql-ipv6.yml
+++ b/docker-compose-mysql-ipv6.yml
@@ -4,7 +4,7 @@ services:
     image: pschiffe/pdns-recursor:${RECURSOR_TAG:-latest}
     networks:
       pdns-mysql:
-        ipv6_address: ${NETWORK_IPV6_PREFIX}::1
+        ipv6_address: ${NETWORK_IPV6_PREFIX}::7
     volumes:
       - /etc/localtime:/etc/localtime:ro
     ulimits:

--- a/docker-compose-mysql-ipv6.yml
+++ b/docker-compose-mysql-ipv6.yml
@@ -4,7 +4,7 @@ services:
     image: pschiffe/pdns-recursor:${RECURSOR_TAG:-latest}
     networks:
       pdns-mysql:
-        - ipv6_address: ${NETWORK_IPV6_PREFIX}::1
+        ipv6_address: ${NETWORK_IPV6_PREFIX}::1
     volumes:
       - /etc/localtime:/etc/localtime:ro
     ulimits:


### PR DESCRIPTION
This fixes `services.pdns-recursor-mysql.networks.pdns-mysql must be a mapping`