### PR TITLE
Move pdns-recursor to fedora 44 and pdns software version 5.4

### DIFF
--- a/pdns-recursor/Dockerfile
+++ b/pdns-recursor/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:43
+FROM fedora:44
 
 RUN arch=$([ "$(arch)" = 'aarch64' ] && echo -n 'arm64' || echo -n 'amd64') \
   && echo 'install_weak_deps=False' >> /etc/dnf/dnf.conf \
@@ -15,7 +15,7 @@ RUN mkdir -p /etc/pdns-recursor/api.d /run/pdns-recursor \
 
 COPY recursor.conf.tpl docker-entrypoint.sh /
 
-ENV VERSION=5.2 \
+ENV VERSION=5.4 \
   PDNS_setuid=pdns-recursor \
   PDNS_setgid=pdns-recursor \
   PDNS_daemon=no \


### PR DESCRIPTION
PowerDNS seems to have been hit by a few CVEs lately. I noticed you can just rebuild pdns-mysql as-is, and you will get a version up to date enough, but you need to bump fedora to get new enough pdns-recusor packages. I didn't check to see if fedora 43 is getting backported package fixes.

I just built these and updated my homelab, will report back if I see any issues.

https://doc.powerdns.com/recursor/security-advisories/powerdns-advisory-2026-03.html